### PR TITLE
Add Ubuntu to tested Oparating Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A constructed language by Jack Eisenmann
 
 This repository is intended to act as a master reference for all external BreadSpeak documentation. This repository also includes scripts for generating documentation resources.
 
-These scripts are intended to run on a Unix-like OS (tested on macOS). The scripts require Node.js and Python 2.7. First install the necessary Node.js packages by running `npm install`. Then execute `fake.bash` to generate BreadSpeak documentation.
+These scripts are intended to run on a Unix-like OS (tested on macOS and Ubuntu). The scripts require Node.js and Python 2.7. First install the necessary Node.js packages by running `npm install`. Then execute `fake.bash` to generate BreadSpeak documentation.
 
 


### PR DESCRIPTION
I ran `npm install` and then executed `fake.bash` without errors and it created the right files.